### PR TITLE
Handle missing probability KPI data without deprecated pandas call

### DIFF
--- a/app.py
+++ b/app.py
@@ -76,9 +76,12 @@ def compute_kpis(g: pd.DataFrame, threshold: float):
     tir = None
     if not g.empty:
         tir = float((g["blood_glucose_level"] < 180).mean() * 100.0)
-    alerts = int((g.get("proba", pd.Series([])) >= threshold).sum()) if "proba" in g else 0
+
+    proba_series = g["proba"] if "proba" in g else pd.Series(dtype=float)
+    alerts = int((proba_series >= threshold).sum())
+
     mean_glucose = float(g["blood_glucose_level"].mean()) if not g.empty else np.nan
-    max_prob = float(g.get("proba", pd.Series([0.0])).max()) if "proba" in g else np.nan
+    max_prob = float(proba_series.max()) if not proba_series.empty else np.nan
     return tir, alerts, mean_glucose, max_prob
 
 def ensure_session():


### PR DESCRIPTION
## Summary
- update KPI calculation to avoid relying on deprecated empty Series defaults
- ensure alerts and maximum probability metrics gracefully handle missing probability data

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e6553737f8832a97248e4f44f034e4